### PR TITLE
Add checkLicenses task to verification group

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -64,6 +64,11 @@ class LicenseToolsPlugin implements Plugin<Project> {
             throw new GradleException("checkLicenses: missing libraries in ${ext.licensesYaml}")
         }
 
+        checkLicenses.configure {
+            group = "Verification"
+            description = 'Check not documented licenses in licenses.yml'
+        }
+
         def generateLicensePage = project.task('generateLicensePage') << {
             initialize(project)
             generateLicensePage(project)


### PR DESCRIPTION
close https://github.com/cookpad/license-tools-plugin/issues/13

``` diff
$ ./gradlew tasks
 ....
 Verification tasks
 ------------------
 check - Runs all checks.
+checkLicenses - Check not documented licenses in licenses.yml
 connectedAndroidTest - Installs and runs instrumentation tests for all flavors on connected devices.
 connectedCheck - Runs all device checks on currently connected devices.
```
