### PR TITLE
Support ISC License

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
@@ -98,6 +98,8 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
                 return "bsd_4_clauses" // not supported because it is a very legacy license
             case ~/(?i).*\bbsd\b.*/:
                 return "bsd_3_clauses"
+            case ~/(?i).*\bisc\b.*/:
+                return "isc"
             default:
                 return name
         }

--- a/plugin/src/main/resources/template/licenses/isc.html
+++ b/plugin/src/main/resources/template/licenses/isc.html
@@ -1,0 +1,25 @@
+<div class="library">
+  <!-- https://opensource.org/licenses/ISC -->
+  <h1 class="title">${library.name}</h1>
+  <% print library.url.isEmpty() ? "" : """<p><a href="${library.url}">${library.url}</a></p>""" %>
+  <div class="license">
+    <h2>ISC License (ISC)</h2>
+    <p>${library.copyrightStatement}</p>
+
+    <p>
+      Permission to use, copy, modify, and/or distribute this software for any purpose
+      with or without fee is hereby granted, provided that the above copyright notice
+      and this permission notice appear in all copies.
+    </p>
+
+    <p>
+      THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+      REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+      FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+      INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+      OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+      TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+      THIS SOFTWARE.
+    </p>
+  </div>
+</div>

--- a/plugin/src/test/groovy/com/cookpad/android/licensetools/LibraryInfoTest.groovy
+++ b/plugin/src/test/groovy/com/cookpad/android/licensetools/LibraryInfoTest.groovy
@@ -71,6 +71,14 @@ public class LibraryInfoTest {
         assertNotEquals("bsd_2_clauses", normalizeLicense("BSD"))
         assertNotEquals("bsd_2_clauses", normalizeLicense("MIT"))
 
+        // ISC
+        assertEquals("isc", normalizeLicense("isc"))
+        assertEquals("isc", normalizeLicense("Isc"))
+        assertEquals("isc", normalizeLicense("ISC"))
+        assertEquals("isc", normalizeLicense("The ISC License"))
+        assertNotEquals("isc", normalizeLicense("Apache 2.0 License"))
+        assertNotEquals("isc", normalizeLicense("MIT"))
+
         // Other
         assertEquals("Other", normalizeLicense("Other"))
         assertEquals("No license found", normalizeLicense("No license found"))


### PR DESCRIPTION
Hi. I'd like to use ISC License by this plugin.
https://opensource.org/licenses/ISC

It used by ORMLite.
https://github.com/j256/ormlite-android

Thank you.
