### PR TITLE
Compare LibraryInfo by artifactId or filename

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
@@ -62,6 +62,10 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
         return libraryName ?: getNameFromArtifactId() ?: filename
     }
 
+    private String getId() {
+        return artifactId ?: filename
+    }
+
     // called from HTML templates
     public String getCopyrightStatement() {
         if (notice) {
@@ -132,7 +136,7 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
 
         LibraryInfo that = (LibraryInfo) o
 
-        if (name != that.name) {
+        if (id != that.id) {
             return false
         }
 
@@ -140,11 +144,11 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
     }
 
     int hashCode() {
-        return name.hashCode()
+        return id.hashCode()
     }
 
     @Override
     int compareTo(LibraryInfo o) {
-        return name.compareToIgnoreCase(o.name)
+        return id.compareToIgnoreCase(o.id)
     }
 }

--- a/plugin/src/test/groovy/com/cookpad/android/licensetools/LibraryInfoTest.groovy
+++ b/plugin/src/test/groovy/com/cookpad/android/licensetools/LibraryInfoTest.groovy
@@ -6,6 +6,7 @@ import static com.cookpad.android.licensetools.LibraryInfo.joinWords
 import static com.cookpad.android.licensetools.LibraryInfo.normalizeLicense
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotEquals
+import static org.junit.Assert.assertTrue
 
 public class LibraryInfoTest {
 
@@ -100,6 +101,62 @@ public class LibraryInfoTest {
         ])
 
         assertEquals("Copyright &copy; Foo. All rights reserved.", libraryInfo.copyrightStatement)
+    }
+
+    @Test
+    public void testEquals() throws Exception {
+        LibraryInfo libraryInfo = LibraryInfo.fromYaml([
+                artifact: "com.example1:foo:1.0"
+        ])
+
+        assertEquals(libraryInfo, LibraryInfo.fromYaml([
+                artifact: "com.example1:foo:1.0"
+        ]))
+        assertNotEquals(libraryInfo, LibraryInfo.fromYaml([
+                artifact: "com.example1:foo:2.0"
+        ]))
+        assertNotEquals(libraryInfo, LibraryInfo.fromYaml([
+                artifact: "com.example1:foo:+"
+        ]))
+        assertNotEquals(libraryInfo, LibraryInfo.fromYaml([
+                artifact: "com.example1:bar:1.0"
+        ]))
+        assertNotEquals(libraryInfo, LibraryInfo.fromYaml([
+                artifact: "com.example2:foo:1.0"
+        ]))
+    }
+
+    @Test
+    public void testCompareTo() throws Exception {
+        LibraryInfo libraryInfo = LibraryInfo.fromYaml([
+                artifact: "com.example1:foo:1.0"
+        ])
+
+        assertEquals(0,
+                libraryInfo.compareTo(LibraryInfo.fromYaml([
+                        artifact: "com.example1:foo:1.0"
+                ]))
+        )
+        assertTrue(
+                libraryInfo.compareTo(LibraryInfo.fromYaml([
+                        artifact: "com.example1:foo:2.0"
+                ])) < 0
+        )
+        assertTrue(
+                libraryInfo.compareTo(LibraryInfo.fromYaml([
+                        artifact: "com.example1:foo:+"
+                ])) > 0
+        )
+        assertTrue(
+                libraryInfo.compareTo(LibraryInfo.fromYaml([
+                        artifact: "com.example1:bar:1.0"
+                ])) > 0
+        )
+        assertTrue(
+                libraryInfo.compareTo(LibraryInfo.fromYaml([
+                        artifact: "com.example2:foo:1.0"
+                ])) < 0
+        )
     }
 
 }


### PR DESCRIPTION
Use `LibraryInfo#artifactId`(or `LibraryInfo#filename`) instead  of `LibraryInfo#name` to compare `LibraryInfo`.

## Why

When using plugins with the same `name`, some libraries are not loaded because `LibraryInfo`s  are not added to `TreeSet` except the first one (at https://github.com/cookpad/license-tools-plugin/blob/693fc6f0c10a26fb681f928b1a9094cfae0f2e88/plugin/src/main/groovy/com/cookpad/android/licensetools/DependencySet.java#L11). 

### Example

When using `com.example1:library:1.0`  and `com.example2:library:1.0`, either one is not loaded.