### PR TITLE
Added ability to completely ignore certain groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ This plugin does not provide `Activity` nor `Fragment` to show `licenses.html`. 
 
 `example/MainActivity` is an example.
 
+### Configuring the plugin
+
+Use `licenseTools` in your build.gradle to add some optional configuration.
+
+For example:
+```
+licenseTools {
+    outputHtml = "licenses_output.html"
+}
+```
+
+Available configuration fields:
+
+| Field name      | Default value      | Description   | 
+| -------------   | -------------      | ------------- |
+| `licensesYaml`  | `"licenses.yml"`   | The name of the licenses yml file                                                                         |
+| `outputHtml`    | `"licenses.html"`  | The file name of the output of the `generateLicensePage` task                                             |
+| `outputHtml`    | `"licenses.json"`  | The file name of the output of the `generateLicenseJson` task                                             |
+| `ignoredGroups` | `[]` (empty array) | An array of group names the plugin will ignore (useful for internal dependencies with missing .pom files) |
+
 ## DataSet Format
 
 ### Required Fields

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsExtension.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsExtension.groovy
@@ -9,4 +9,6 @@ public class LicenseToolsExtension {
     public File outputHtml = new File("licenses.html");
 
     public File outputJson = new File("licenses.json");
+
+    public Set<String> ignoredGroups = new HashSet<>();
 }

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -91,7 +91,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
     void initialize(Project project) {
         LicenseToolsExtension ext = project.extensions.findByType(LicenseToolsExtension)
         loadLibrariesYaml(project.file(ext.licensesYaml))
-        loadDependencyLicenses(project)
+        loadDependencyLicenses(project, ext.ignoredGroups)
     }
 
     void loadLibrariesYaml(File licensesYaml) {
@@ -106,9 +106,12 @@ class LicenseToolsPlugin implements Plugin<Project> {
         }
     }
 
-    void loadDependencyLicenses(Project project) {
+    void loadDependencyLicenses(Project project, Set<String> ignoredGroups) {
         resolveProjectDependencies(project).each { d ->
             if (d.moduleVersion.id.version == "unspecified") {
+                return
+            }
+            if (ignoredGroups.contains(d.moduleVersion.id.group)) {
                 return
             }
 


### PR DESCRIPTION
This is useful for internal module dependencies that don't have a proper .pom file or maven-metadata.xml

example usage:
```
licenseTools {
    ignoredGroups = ["mycompany_name"]
}
```