### PR TITLE
Place an expand/collapse button at each license document

### DIFF
--- a/example/src/main/assets/licenses.html
+++ b/example/src/main/assets/licenses.html
@@ -43,6 +43,35 @@
     list-style-type: lower-alpha;
     padding-left: 2em;
     }
+    input ~ .license {
+    max-height: 200px;
+    overflow: hidden;
+    }
+    input, label {
+    position: absolute;
+    right: 16px;
+    width: 12px;
+    height: 12px;
+    margin: 20px;
+    }
+    input {
+    opacity: 0;
+    z-index: 1;
+    }
+    label {
+    margin-top: 16px;
+    text-align: center;
+    font-weight: bold;
+    }
+    label::before {
+    content: "+";
+    }
+    input:checked + label::before {
+    content: "-";
+    }
+    input:checked ~ .license {
+    max-height: none;
+    }
   </style>
 </head>
 <body>
@@ -50,7 +79,8 @@
       <!-- https://opensource.org/licenses/Apache-2.0 -->
       <h1 class="title">Android Support Libraries</h1>
       <p class="notice">Copyright &copy; The Android Open Source Project. All rights reserved.</p>
-      
+
+      <input type="checkbox"><label></label>
       <div class="license">
         <h2>
           Apache License
@@ -306,7 +336,7 @@
           <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following
             disclaimer.
           </li>
-    
+
           <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
             disclaimer in the documentation and/or other materials provided with the distribution.
           </li>
@@ -326,7 +356,8 @@
       <!-- https://opensource.org/licenses/Apache-2.0 -->
       <h1 class="title">Android Orma</h1>
       <p class="notice">Copyright (c) 2015 FUJI Goro (gfx)<br/>SQLite.g4 is: Copyright (c) 2014 by Bart Kiers<br/></p>
-      
+
+      <input type="checkbox"><label></label>
       <div class="license">
         <h2>
           Apache License
@@ -572,7 +603,8 @@
       <!-- https://opensource.org/licenses/Apache-2.0 -->
       <h1 class="title">Gson</h1>
       <p class="notice">Copyright &copy; Google Inc. All rights reserved.</p>
-      
+
+      <input type="checkbox"><label></label>
       <div class="license">
         <h2>
           Apache License
@@ -818,7 +850,8 @@
       <!-- https://opensource.org/licenses/Apache-2.0 -->
       <h1 class="title">Picasso</h1>
       <p class="notice">Copyright &copy; Square, Inc. All rights reserved.</p>
-      
+
+      <input type="checkbox"><label></label>
       <div class="license">
         <h2>
           Apache License
@@ -1063,7 +1096,7 @@
     <div class="library">
       <!-- https://opensource.org/licenses/BSD-3-Clause -->
       <h1 class="title">ANTLR4</h1>
-      
+
       <div class="license">
         <p>Copyright &copy; Terence Parr and Sam Harwell. All rights reserved.</p>
         <p>
@@ -1097,6 +1130,7 @@
       <h1 class="title">RxAndroid</h1>
       <p class="notice">Copyright &copy; The RxAndroid authors. All rights reserved.</p>
       <p><a href="https://github.com/ReactiveX/RxAndroid">https://github.com/ReactiveX/RxAndroid</a></p>
+      <input type="checkbox"><label></label>
       <div class="license">
         <h2>
           Apache License
@@ -1343,6 +1377,7 @@
       <h1 class="title">RxJava</h1>
       <p class="notice">Copyright &copy; Netflix, Inc. All rights reserved.</p>
       <p><a href="https://github.com/ReactiveX/RxJava">https://github.com/ReactiveX/RxJava</a></p>
+      <input type="checkbox"><label></label>
       <div class="license">
         <h2>
           Apache License
@@ -1589,7 +1624,7 @@
       <p><a href="http://www.reactive-streams.org/">http://www.reactive-streams.org/</a></p>
       <div class="license">
         <h2>CC0 1.0 Universal</h2>
-    
+
         <blockquote>
           CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT
           PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES
@@ -1726,8 +1761,8 @@
             Commons is not a party to this document and has no duty or
             obligation with respect to this CC0 or use of the Work.</li>
         </ol>
-    
-    
+
+
       </div>
     </div>
 

--- a/plugin/src/main/resources/template/layout.html
+++ b/plugin/src/main/resources/template/layout.html
@@ -43,6 +43,35 @@
     list-style-type: lower-alpha;
     padding-left: 2em;
     }
+    input ~ .license {
+    max-height: 200px;
+    overflow: hidden;
+    }
+    input, label {
+    position: absolute;
+    right: 16px;
+    width: 12px;
+    height: 12px;
+    margin: 20px;
+    }
+    input {
+    opacity: 0;
+    z-index: 1;
+    }
+    label {
+    margin-top: 16px;
+    text-align: center;
+    font-weight: bold;
+    }
+    label::before {
+    content: "+";
+    }
+    input:checked + label::before {
+    content: "-";
+    }
+    input:checked ~ .license {
+    max-height: none;
+    }
   </style>
 </head>
 <body>

--- a/plugin/src/main/resources/template/licenses/apache2.html
+++ b/plugin/src/main/resources/template/licenses/apache2.html
@@ -3,6 +3,7 @@
   <h1 class="title">${library.name}</h1>
   <p class="notice">${library.copyrightStatement.replaceAll("\n", "<br/>")}</p>
   <% print library.url.isEmpty() ? "" : """<p><a href="${library.url}">${library.url}</a></p>""" %>
+  <input type="checkbox"><label></label>
   <div class="license">
     <h2>
       Apache License

--- a/plugin/src/main/resources/template/licenses/epl1.html
+++ b/plugin/src/main/resources/template/licenses/epl1.html
@@ -3,6 +3,7 @@
   <h1 class="title">${library.name}</h1>
   <p class="notice">${library.copyrightStatement.replaceAll("\n", "<br/>")}</p>
   <% print library.url.isEmpty() ? "" : """<p><a href="${library.url}">${library.url}</a></p>""" %>
+  <input type="checkbox"><label></label>
   <div class="license">
     <h2>Eclipse Public License - v 1.0</h2>
     <p>

--- a/plugin/src/main/resources/template/licenses/mpl1.html
+++ b/plugin/src/main/resources/template/licenses/mpl1.html
@@ -3,6 +3,7 @@
   <h1 class="title">${library.name}</h1>
   <p class="notice">${library.copyrightStatement.replaceAll("\n", "<br/>")}</p>
   <% print library.url.isEmpty() ? "" : """<p><a href="${library.url}">${library.url}</a></p>""" %>
+  <input type="checkbox"><label></label>
   <div class="license">
     <h2>Mozilla Public License, version 1.1</h2>
     <h2>1. Definitions.</h2>

--- a/plugin/src/main/resources/template/licenses/mpl2.html
+++ b/plugin/src/main/resources/template/licenses/mpl2.html
@@ -3,6 +3,7 @@
   <h1 class="title">${library.name}</h1>
   <p class="notice">${library.copyrightStatement.replaceAll("\n", "<br/>")}</p>
   <% print library.url.isEmpty() ? "" : """<p><a href="${library.url}">${library.url}</a></p>""" %>
+  <input type="checkbox"><label></label>
   <div class="license">
     <h2>Mozilla Public License, version 2.0</h2>
     <h2>1. Definitions.</h2>


### PR DESCRIPTION
Some license documents, such as Apache License, are too long to scroll them.

I added the style to place an expand/collapse button at the top right of each license document.

I implemented the feature with pure CSS because I don't want to call `webView.getSettings().setJavaScriptEnabled(true)`.

### Limitation

- The feature does not work in Android 4.2.2 because it does not support general sibling selectors (`A ~ B`)
  - It is not critical issue, I think,  because Android 4.2.x is old enough and at least you can see header of the license document.