### PR TITLE
Make checkLicenses task append not-listed libraries to licenses.yml automatically

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
@@ -62,6 +62,10 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
         return libraryName ?: getNameFromArtifactId() ?: filename
     }
 
+    public String getEscapedName() {
+        return name.contains(": ") ? "\"${name}\"" : name
+    }
+
     private String getId() {
         return artifactId ?: filename
     }

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -51,6 +51,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
                         message.append("  url: ${libraryInfo.url ?: "#URL#"}\n")
                     }
                     project.logger.warn(message.toString().trim())
+                    appendToLicenseYaml(project, message.toString().trim())
                 }
             }
             if (notInDependencies.size() > 0) {
@@ -156,6 +157,12 @@ class LicenseToolsPlugin implements Plugin<Project> {
 
     Map<String, ?> loadYaml(File yamlFile) {
         return yaml.load(yamlFile.text) as Map<String, ?> ?: [:]
+    }
+
+    void appendToLicenseYaml(Project project, String content) {
+        def ext = project.extensions.getByType(LicenseToolsExtension)
+
+        project.file(ext.licensesYaml).append("\n${content}")
     }
 
     void generateLicensePage(Project project) {

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -41,7 +41,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
                 notDocumented.each { libraryInfo ->
                     def message = new StringBuffer()
                     message.append("- artifact: ${libraryInfo.artifactId.withWildcardVersion()}\n")
-                    message.append("  name: ${libraryInfo.name ?: "#NAME#"}\n")
+                    message.append("  name: ${libraryInfo.escapedName ?: "#NAME#"}\n")
                     message.append("  copyrightHolder: ${libraryInfo.copyrightHolder ?: "#COPYRIGHT_HOLDER#"}\n")
                     message.append("  license: ${libraryInfo.license ?: "#LICENSE#"}\n")
                     if (libraryInfo.licenseUrl) {


### PR DESCRIPTION
`How To Use` says that you will **see** the following messages by running the checkLicenses task.

```
- artifact: com.android.support:support-v4:+
  name: #NAME#
  copyrightHolder: #AUTHOR#
  license: No license found
- artifact: com.android.support:animated-vector-drawable:+
  name: #NAME#
  copyrightHolder: #AUTHOR#
  license: No license found
- artifact: io.reactivex:rxjava:+
  name: #NAME#
  copyrightHolder: #AUTHOR#
  license: apache2
```

It is a little bit annoying for me to copy and paste the messages from console to licenses.yml.
So I make checkLicenses task append not-listed libraries to licenses.yml automatically.

In addition, if you use retrofit2:adapter-rxjava2 or retrofit2:converter-gson,
generated licenses.yml will be invalid because their name contains colon with space (: ).
Colon with space is invalid in YAML format, so I escaped it as below.

```
- artifact: com.squareup.retrofit2:adapter-rxjava2:+
  name: "Adapter: RxJava 2"
- artifact: com.squareup.retrofit2:converter-gson:+
  name: "Converter: Gson"
```