### PR TITLE
Support local Jar libraries and override incorrect pom.xml

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -1,7 +1,6 @@
 package com.cookpad.android.licensetools
 
 import groovy.util.slurpersupport.GPathResult
-import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -65,7 +64,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
                     project.logger.warn("- artifact: ${libraryInfo.artifactId}\n  license: ${libraryInfo.license}")
                 }
             }
-            throw new GradleException("checkLicenses: missing libraries in ${ext.licensesYaml}")
+            project.logger.error("checkLicenses: missing libraries in ${ext.licensesYaml}")
         }
 
         checkLicenses.configure {

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -172,12 +172,10 @@ class LicenseToolsPlugin implements Plugin<Project> {
             // merge dependencyLicenses's libraryInfo into librariesYaml's
             def o = dependencyLicenses.find(libraryInfo.artifactId)
             if (o) {
-                if (!libraryInfo.license) {
-                    libraryInfo.license = o.license
-                }
+                libraryInfo.license = libraryInfo.license ?: o.license
                 libraryInfo.filename = o.filename
                 libraryInfo.artifactId = o.artifactId
-                libraryInfo.url = o.url.isEmpty() ? libraryInfo.url ?: "" : o.url
+                libraryInfo.url = libraryInfo.url ?: o.url
             }
             try {
                 content.append(Templates.buildLicenseHtml(libraryInfo));
@@ -213,12 +211,10 @@ class LicenseToolsPlugin implements Plugin<Project> {
             // merge dependencyLicenses's libraryInfo into librariesYaml's
             def o = dependencyLicenses.find(libraryInfo.artifactId)
             if (o) {
-                if (!libraryInfo.license) {
-                    libraryInfo.license = o.license
-                }
+                libraryInfo.license = libraryInfo.license ?: o.license
                 // libraryInfo.filename = o.filename
                 libraryInfo.artifactId = o.artifactId
-                libraryInfo.url = o.url.isEmpty() ? libraryInfo.url ?: "" : o.url
+                libraryInfo.url = libraryInfo.url ?: o.url
             }
             try {
                 Templates.assertLicenseAndStatement(libraryInfo)

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -171,12 +171,14 @@ class LicenseToolsPlugin implements Plugin<Project> {
 
             // merge dependencyLicenses's libraryInfo into librariesYaml's
             def o = dependencyLicenses.find(libraryInfo.artifactId)
-            if (!libraryInfo.license) {
-                libraryInfo.license = o.license
+            if (o) {
+                if (!libraryInfo.license) {
+                    libraryInfo.license = o.license
+                }
+                libraryInfo.filename = o.filename
+                libraryInfo.artifactId = o.artifactId
+                libraryInfo.url = o.url.isEmpty() ? libraryInfo.url ?: "" : o.url
             }
-            libraryInfo.filename = o.filename
-            libraryInfo.artifactId = o.artifactId
-            libraryInfo.url = o.url.isEmpty() ? libraryInfo.url ?: "" : o.url
             try {
                 content.append(Templates.buildLicenseHtml(libraryInfo));
             } catch (NotEnoughInformationException e) {
@@ -210,12 +212,14 @@ class LicenseToolsPlugin implements Plugin<Project> {
 
             // merge dependencyLicenses's libraryInfo into librariesYaml's
             def o = dependencyLicenses.find(libraryInfo.artifactId)
-            if (!libraryInfo.license) {
-                libraryInfo.license = o.license
+            if (o) {
+                if (!libraryInfo.license) {
+                    libraryInfo.license = o.license
+                }
+                // libraryInfo.filename = o.filename
+                libraryInfo.artifactId = o.artifactId
+                libraryInfo.url = o.url.isEmpty() ? libraryInfo.url ?: "" : o.url
             }
-            // libraryInfo.filename = o.filename
-            libraryInfo.artifactId = o.artifactId
-            libraryInfo.url = o.url.isEmpty() ? libraryInfo.url ?: "" : o.url
             try {
                 Templates.assertLicenseAndStatement(libraryInfo)
                 librariesArray << libraryInfo


### PR DESCRIPTION
### Case 1: local Jar libraries and copied source codes under OSS license

Many developers use local Jar libraries, but license-tools-plugin checks only compile configuration in dependencies.
checkLicenses/generateLicensePage task fails even if you define Jar library information in licenses.yml manually.
Then you need to modify assets/licenses.html every time it is generated. It's a hassle.

I made checkLicenses task not throw exception but only log error message when missing libraries are found in licenses.yml.
For example, if you still use obsolete Apache HttpClient unfortunately, you just write as below.

```
- artifact: org.apache.http:+:+
  name: Apache HttpClient
  copyrightHolder: Apache Software Foundation
  license: apache2
  url: http://hc.apache.org/httpcomponents-client-ga/
```

And some developers may copy source codes published under OSS license to customize (hack) them.
In this case you can write copied source codes information to licenses.yml as well.

### Case 2: incorrect or inappropriate pom.xml

In some libraries, pom.xml is not maintained and not updated to the latest information.
Then incorrect information can be defined in pom.xml.
If you write correct information in licenses.yml, but license-tools-plugin prioritizes pom.xml over licenses.yml.

And you may want to override library information pom.xml
because they are inappropriate for you.

In order to solve the above problem, I made the plugin prioritize licenses.yml over pom.xml.