### PR TITLE
Escape colon with space (: ) in library name as it is invalid in YAML format

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
@@ -62,6 +62,10 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
         return libraryName ?: getNameFromArtifactId() ?: filename
     }
 
+    public String getEscapedName() {
+        return name.contains(": ") ? "\"${name}\"" : name
+    }
+
     private String getId() {
         return artifactId ?: filename
     }

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -40,7 +40,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
                 notDocumented.each { libraryInfo ->
                     def message = new StringBuffer()
                     message.append("- artifact: ${libraryInfo.artifactId.withWildcardVersion()}\n")
-                    message.append("  name: ${libraryInfo.name ?: "#NAME#"}\n")
+                    message.append("  name: ${libraryInfo.escapedName ?: "#NAME#"}\n")
                     message.append("  copyrightHolder: ${libraryInfo.copyrightHolder ?: "#COPYRIGHT_HOLDER#"}\n")
                     message.append("  license: ${libraryInfo.license ?: "#LICENSE#"}\n")
                     if (libraryInfo.licenseUrl) {


### PR DESCRIPTION
(This PR was split from https://github.com/cookpad/license-tools-plugin/pull/51)

 if you use retrofit2:adapter-rxjava2 or retrofit2:converter-gson,
generated licenses.yml will be invalid because their name contains colon with space (: ).
Colon with space is invalid in YAML format, so I escaped it as below.

```
- artifact: com.squareup.retrofit2:adapter-rxjava2:+
  name: "Adapter: RxJava 2"
- artifact: com.squareup.retrofit2:converter-gson:+
  name: "Converter: Gson"
```