### PR TITLE
Add updateLicenses task to append missing libraries to licenses.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Gradle Plugin to check library licenses and generate license pages.
 
 * `./gradlew checkLicenses` to check licenses in dependencies
+* `./gradlew updateLicenses` to update a library information file `licenses.yml`
 * `./gradlew generateLicensePage` to generate a license page `licenses.html`
 * `./gradlew generateLicenseJson` to generate a license json file `licenses.json`
 
@@ -46,8 +47,8 @@ You will see the following messages by `./gradlew checkLicenses`:
   name: #NAME#
   copyrightHolder: #AUTHOR#
   license: apache2
- ```
- 
+```
+
 ### Add library licenses to `app/licenses.yml`
 
 Then, Create `app/licenses.yml`, and add libraries listed the above with required fields:
@@ -65,6 +66,9 @@ Then, Create `app/licenses.yml`, and add libraries listed the above with require
 
 You can use wildcards in artifact names and versions.
 You'll know the Android support libraries are grouped in `com.android.support` so you use `com.android.support:+:+` here.
+
+Instead of manually appending missing libraries to `licenses.yml`,
+you can also run the `updateLicenses` task to update `licenses.yml` automatically.
 
 Then, `./gradlew checkLicenses` will passes.
 

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -38,18 +38,8 @@ class LicenseToolsPlugin implements Plugin<Project> {
             if (notDocumented.size() > 0) {
                 project.logger.warn("# Libraries not listed in ${ext.licensesYaml}:")
                 notDocumented.each { libraryInfo ->
-                    def message = new StringBuffer()
-                    message.append("- artifact: ${libraryInfo.artifactId.withWildcardVersion()}\n")
-                    message.append("  name: ${libraryInfo.name ?: "#NAME#"}\n")
-                    message.append("  copyrightHolder: ${libraryInfo.copyrightHolder ?: "#COPYRIGHT_HOLDER#"}\n")
-                    message.append("  license: ${libraryInfo.license ?: "#LICENSE#"}\n")
-                    if (libraryInfo.licenseUrl) {
-                        message.append("  licenseUrl: ${libraryInfo.licenseUrl ?: "#LICENSEURL#"}\n")
-                    }
-                    if (libraryInfo.url) {
-                        message.append("  url: ${libraryInfo.url ?: "#URL#"}\n")
-                    }
-                    project.logger.warn(message.toString().trim())
+                    def text = generateLibraryInfoText(libraryInfo)
+                    project.logger.warn(text)
                 }
             }
             if (notInDependencies.size() > 0) {
@@ -71,6 +61,19 @@ class LicenseToolsPlugin implements Plugin<Project> {
             group = "Verification"
             description = 'Check whether dependency licenses are listed in licenses.yml'
         }
+
+        def updateLicenses = project.task('updateLicenses').doLast {
+            initialize(project)
+
+            def notDocumented = dependencyLicenses.notListedIn(librariesYaml)
+            LicenseToolsExtension ext = project.extensions.findByType(LicenseToolsExtension)
+
+            notDocumented.each { libraryInfo ->
+                def text = generateLibraryInfoText(libraryInfo)
+                project.file(ext.licensesYaml).append("\n${text}")
+            }
+        }
+        updateLicenses.dependsOn('checkLicenses')
 
         def generateLicensePage = project.task('generateLicensePage').doLast {
             initialize(project)
@@ -155,6 +158,21 @@ class LicenseToolsPlugin implements Plugin<Project> {
 
     Map<String, ?> loadYaml(File yamlFile) {
         return yaml.load(yamlFile.text) as Map<String, ?> ?: [:]
+    }
+
+    static String generateLibraryInfoText(LibraryInfo libraryInfo) {
+        def text = new StringBuffer()
+        text.append("- artifact: ${libraryInfo.artifactId.withWildcardVersion()}\n")
+        text.append("  name: ${libraryInfo.name ?: "#NAME#"}\n")
+        text.append("  copyrightHolder: ${libraryInfo.copyrightHolder ?: "#COPYRIGHT_HOLDER#"}\n")
+        text.append("  license: ${libraryInfo.license ?: "#LICENSE#"}\n")
+        if (libraryInfo.licenseUrl) {
+            text.append("  licenseUrl: ${libraryInfo.licenseUrl ?: "#LICENSEURL#"}\n")
+        }
+        if (libraryInfo.url) {
+            text.append("  url: ${libraryInfo.url ?: "#URL#"}\n")
+        }
+        return text.toString().trim()
     }
 
     void generateLicensePage(Project project) {


### PR DESCRIPTION
(This PR was split from https://github.com/cookpad/license-tools-plugin/pull/51)

`How To Use` says that you will **see** the following messages by running the `checkLicenses` task.

```
- artifact: com.android.support:support-v4:+
  name: #NAME#
  copyrightHolder: #AUTHOR#
  license: No license found
- artifact: com.android.support:animated-vector-drawable:+
  name: #NAME#
  copyrightHolder: #AUTHOR#
  license: No license found
- artifact: io.reactivex:rxjava:+
  name: #NAME#
  copyrightHolder: #AUTHOR#
  license: apache2
```

It is a little bit annoying for me to copy and paste the messages from console to `licenses.yml`.
So I add new `updateLicenses` task to append not-listed libraries to `licenses.yml` automatically.