### PR TITLE
Improve that did not fail on :checkLicense

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -1,6 +1,7 @@
 package com.cookpad.android.licensetools
 
 import groovy.util.slurpersupport.GPathResult
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -64,7 +65,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
                     project.logger.warn("- artifact: ${libraryInfo.artifactId}\n  license: ${libraryInfo.license}")
                 }
             }
-            project.logger.error("checkLicenses: missing libraries in ${ext.licensesYaml}")
+            throw new GradleException("checkLicenses: missing libraries in ${ext.licensesYaml}")
         }
 
         checkLicenses.configure {


### PR DESCRIPTION
Now on master, `:checkLicense` task does not fail when license is missing.

This PR improve it.