### PR TITLE
fix resolving dependencies for project

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -89,10 +89,10 @@
             </value>
           </option>
         </AndroidXmlCodeStyleSettings>
-        <MarkdownNavigatorCodeStyleSettings>
-          <option name="RIGHT_MARGIN" value="72" />
-        </MarkdownNavigatorCodeStyleSettings>
         <Objective-C-extensions>
+          <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
+          <option name="RELEASE_STYLE" value="IVAR" />
+          <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE" />
           <file>
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -89,10 +89,10 @@
             </value>
           </option>
         </AndroidXmlCodeStyleSettings>
+        <MarkdownNavigatorCodeStyleSettings>
+          <option name="RIGHT_MARGIN" value="72" />
+        </MarkdownNavigatorCodeStyleSettings>
         <Objective-C-extensions>
-          <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
-          <option name="RELEASE_STYLE" value="IVAR" />
-          <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE" />
           <file>
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,10 @@ ext {
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha9'
         classpath 'com.novoda:bintray-release:0.4.0' // https://github.com/novoda/bintray-release
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha9'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.novoda:bintray-release:0.4.0' // https://github.com/novoda/bintray-release
     }
 }

--- a/example-dep/build.gradle
+++ b/example-dep/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 16

--- a/example-dep/build.gradle
+++ b/example-dep/build.gradle
@@ -22,8 +22,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion '26.0.2'
 
     dataBinding {
         enabled = true
@@ -50,7 +50,7 @@ licenseTools {
 }
 
 dependencies {
-    implementation project(':example-dep')
+    implementation project(path: ':example-dep', configuration: 'default')
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:appcompat-v7:25.3.1'
     implementation 'com.android.support:cardview-v7:25.3.1'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.cookpad.android.licensetools'
 
+repositories {
+    google() //required for databinding
+}
+
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
@@ -15,6 +19,12 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                includeCompileClasspath false
+            }
+        }
     }
     buildTypes {
         release {
@@ -40,21 +50,21 @@ licenseTools {
 }
 
 dependencies {
-    compile project(':example-dep')
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:cardview-v7:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
-    compile 'io.reactivex:rxandroid:1.1.0'
-    compile 'com.google.code.gson:gson:2.6.2'
+    implementation project(':example-dep')
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    implementation 'com.android.support:cardview-v7:25.3.1'
+    implementation 'com.android.support:recyclerview-v7:25.3.1'
+    implementation 'io.reactivex:rxandroid:1.1.0'
+    implementation 'com.google.code.gson:gson:2.6.2'
     annotationProcessor 'com.github.gfx.android.orma:orma-processor:2.4.5'
-    compile 'com.github.gfx.android.orma:orma:2.4.5'
-    compile 'com.google.android.gms:play-services-maps:8.4.0'
-    compile 'com.google.android.gms:play-services-location:8.4.0'
-    compile 'com.google.android.gms:play-services-analytics:8.4.0'
-    compile 'org.reactivestreams:reactive-streams:1.0.1-RC2'
-    releaseCompile  'com.squareup.picasso:picasso:2.5.2'
-    debugCompile 'com.facebook.stetho:stetho:1.3.1'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
+    implementation 'com.github.gfx.android.orma:orma:2.4.5'
+    implementation 'com.google.android.gms:play-services-maps:8.4.0'
+    implementation 'com.google.android.gms:play-services-location:8.4.0'
+    implementation 'com.google.android.gms:play-services-analytics:8.4.0'
+    implementation 'org.reactivestreams:reactive-streams:1.0.1-RC2'
+    releaseImplementation  'com.squareup.picasso:picasso:2.5.2'
+    debugImplementation 'com.facebook.stetho:stetho:1.3.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest-library:1.3'
 }

--- a/example/licenses.yml
+++ b/example/licenses.yml
@@ -49,3 +49,16 @@
   license: CC0
   licenseUrl: http://creativecommons.org/publicdomain/zero/1.0/
   url: http://www.reactive-streams.org/
+- artifact: org.apache.commons:commons-lang3:+
+  name: Apache Commons Lang
+  copyrightHolder: #COPYRIGHT_HOLDER#
+  license: #LICENSE#
+  url: http://commons.apache.org/proper/commons-lang/
+  skip: true
+- artifact: org.yaml:snakeyaml:+
+  name: SnakeYAML
+  copyrightHolder: #COPYRIGHT_HOLDER#
+  license: Apache License, Version 2.0
+  licenseUrl: http://www.apache.org/licenses/LICENSE-2.0.txt
+  url: http://www.snakeyaml.org
+  skip: true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 27 13:55:02 JST 2016
+#Sat Nov 04 19:54:02 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    compile 'com.android.tools.build:gradle:2.3.1'
     compile 'org.yaml:snakeyaml:1.17'
     compile 'org.apache.commons:commons-lang3:3.4'
     testCompile 'junit:junit:4.12'

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/ArtifactId.java
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/ArtifactId.java
@@ -1,8 +1,5 @@
 package com.cookpad.android.licensetools;
 
-import com.android.annotations.NonNullByDefault;
-
-@NonNullByDefault
 public class ArtifactId implements Comparable<ArtifactId> {
 
     public final String group;

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
@@ -8,9 +8,9 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
 
     String filename = ""
 
-    String year = "";
+    String year = ""
 
-    String copyrightHolder = "";
+    String copyrightHolder = ""
 
     String notice = ""
 
@@ -18,7 +18,7 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
 
     String licenseUrl = ""
 
-    String url = "";
+    String url = ""
 
     boolean skip = false
 


### PR DESCRIPTION
fix: https://github.com/cookpad/license-tools-plugin/issues/58

----

## What I did in this PR
- add `configuration: 'default'` in `project`as a workaround for Gradle 3.0 and update Gradle 4.3
    - https://stackoverflow.com/questions/45679847/android-studio-3-0-compile-issue-cannot-choose-between-configurations
- Get dependencies from **ALL** subprojects
- I've checked plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy works against 
`'com.android.tools.build:gradle:2.3.1'`, too.

## What should we do
- After merging this PR:
    - We should notice about `configuration: 'default'` in README or release note
        - Since without the configuration, `Error:Cannot choose between the following configurations of project...` is raised.
    - We should notice about we start getting **ALL** subprojects' dependencies 