### PR TITLE
Support custom license text template

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
@@ -22,6 +22,8 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
 
     boolean skip = false
 
+    String licenseBody = ''
+
     // from libraries.yml
     public static LibraryInfo fromYaml(Object lib) {
         def libraryInfo = new LibraryInfo()
@@ -43,6 +45,7 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
         libraryInfo.notice = lib.notice as String
         libraryInfo.skip = lib.skip as boolean
         libraryInfo.url = lib.url as String
+        libraryInfo.licenseBody = lib.licenseBody as String
         return libraryInfo
     }
 
@@ -163,6 +166,8 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
             case ~/(?i).*\bgpl\b?.*3.*/:
             case ~/(?i).*\bgpl\b.*/:
                 return "gpl3"
+            case ~/(?i).*\bcustom\b.*/:
+                return "custom"
             default:
                 return name
         }

--- a/plugin/src/main/resources/template/licenses/custom.html
+++ b/plugin/src/main/resources/template/licenses/custom.html
@@ -1,0 +1,8 @@
+<div class="library">
+  <!-- to support custom license -->
+  <h1 class="title">${library.name}</h1>
+  <% print library.url.isEmpty() ? "" : """<p><a href="${library.url}">${library.url}</a></p>""" %>
+  <div class="license">
+      <p>${library.licenseBody.replaceAll("\n", "<br/>")}</p>
+  </div>
+</div>


### PR DESCRIPTION
There are some license texts different from official template or used
custom template.
It can be supported by using 'custom' template, with licenseBody item.

Example)
- artifact: com.what.ever:+:+
  name: Awesome Library
  license: custom
  licenseBody: |
      original license line 1
      original license line 2
      ...