### PR TITLE
Add new line after license for better readability

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -209,7 +209,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
             text.append("  licenseUrl: ${libraryInfo.licenseUrl ?: "#LICENSEURL#"}\n")
         }
         if (libraryInfo.url) {
-            text.append("  url: ${libraryInfo.url ?: "#URL#"}\n")
+            text.append("  url: ${libraryInfo.url ?: "#URL#"}\n\n")
         }
         return text.toString().trim()
     }


### PR DESCRIPTION
Since the licences are now automatically added to the yml file, I'd like to add better readability by adding a new line after every license addition.