### PR TITLE
Fix #100 : Generate YAML compatible text

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -174,8 +174,8 @@ class LicenseToolsPlugin implements Plugin<Project> {
         }
     }
 
-    Map<String, ?> loadYaml(File yamlFile) {
-        return yaml.load(yamlFile.text) as Map<String, ?> ?: [:]
+    static Map<String, ?>[] loadYaml(File yamlFile) {
+        return YAML.load(yamlFile.text) as Map<String, ?>[] ?: []
     }
 
     void generateLicensePage(Project project) {

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -217,18 +217,23 @@ class LicenseToolsPlugin implements Plugin<Project> {
     }
 
     static String generateLibraryInfoText(LibraryInfo libraryInfo) {
-        def text = new StringBuffer()
-        text.append("- artifact: ${libraryInfo.artifactId.withWildcardVersion()}\n")
-        text.append("  name: ${libraryInfo.name ?: "#NAME#"}\n")
-        text.append("  copyrightHolder: ${libraryInfo.copyrightHolder ?: "#COPYRIGHT_HOLDER#"}\n")
-        text.append("  license: ${libraryInfo.license ?: "#LICENSE#"}\n")
+        def data = [
+                artifact: libraryInfo.artifactId.withWildcardVersion(),
+                name: libraryInfo.name ?: "#NAME#",
+                copyrightHolder: libraryInfo.copyrightHolder ?: "#COPYRIGHT_HOLDER#",
+                license: libraryInfo.license ?: "#LICENSE#",
+        ]
+
         if (libraryInfo.licenseUrl) {
-            text.append("  licenseUrl: ${libraryInfo.licenseUrl ?: "#LICENSEURL#"}\n")
+            data["licenseUrl"] = libraryInfo.licenseUrl ?: "#LICENSEURL#"
         }
+
         if (libraryInfo.url) {
-            text.append("  url: ${libraryInfo.url ?: "#URL#"}\n")
+            data["url"] = libraryInfo.url ?: "#URL#"
         }
-        return text.toString().trim()
+
+        // Dump the info like one of array elements
+        return YAML.dump([data])
     }
 
     void generateLicenseJson(Project project) {

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -9,11 +9,28 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.xml.sax.helpers.DefaultHandler
+import org.yaml.snakeyaml.DumperOptions
+import org.yaml.snakeyaml.DumperOptions.FlowStyle
+import org.yaml.snakeyaml.DumperOptions.ScalarStyle
 import org.yaml.snakeyaml.Yaml
 
 class LicenseToolsPlugin implements Plugin<Project> {
 
-    final yaml = new Yaml()
+    static final Yaml YAML
+
+    static {
+        DumperOptions options = new DumperOptions()
+
+        options.with {
+            explicitStart = false
+            explicitEnd = false
+            canonical = false
+            defaultFlowStyle = FlowStyle.BLOCK
+            defaultScalarStyle = ScalarStyle.DOUBLE_QUOTED
+        }
+
+        YAML = new Yaml(options)
+    }
 
     final DependencySet librariesYaml = new DependencySet() // based on libraries.yml
     final DependencySet dependencyLicenses = new DependencySet() // based on license plugin's dependency-license.xml

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.artifacts.ResolvedArtifact
 import org.xml.sax.helpers.DefaultHandler
 import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.DumperOptions.FlowStyle
+import org.yaml.snakeyaml.DumperOptions.LineBreak
 import org.yaml.snakeyaml.DumperOptions.ScalarStyle
 import org.yaml.snakeyaml.Yaml
 
@@ -27,6 +28,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
             canonical = false
             defaultFlowStyle = FlowStyle.BLOCK
             defaultScalarStyle = ScalarStyle.DOUBLE_QUOTED
+            lineBreak = LineBreak.UNIX
         }
 
         YAML = new Yaml(options)

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -29,6 +29,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
             defaultFlowStyle = FlowStyle.BLOCK
             defaultScalarStyle = ScalarStyle.DOUBLE_QUOTED
             lineBreak = LineBreak.UNIX
+            indent = 2
         }
 
         YAML = new Yaml(options)
@@ -235,12 +236,12 @@ class LicenseToolsPlugin implements Plugin<Project> {
         }
 
         // Dump the info like one of array elements
-        return YAML.dump([datum])
+        return YAML.dump([datum]).trim()
     }
 
     static String generateMissingLibraryInfoText(LibraryInfo libraryInfo) {
         def datum = [
-                artifact: libraryInfo.artifactId,
+                artifact: libraryInfo.artifactId.toString(),
                 name: libraryInfo.name,
         ]
 
@@ -254,7 +255,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
         }
 
         // Dump the info like one of array elements
-        return YAML.dump([datum])
+        return YAML.dump([datum]).trim()
     }
 
     void generateLicenseJson(Project project) {

--- a/plugin/src/test/groovy/com/cookpad/android/licensetools/LicenseToolsPluginTest.groovy
+++ b/plugin/src/test/groovy/com/cookpad/android/licensetools/LicenseToolsPluginTest.groovy
@@ -6,112 +6,134 @@ import org.yaml.snakeyaml.Yaml
 import static com.cookpad.android.licensetools.LibraryInfo.joinWords
 
 class LicenseToolsPluginTest {
-    private static def yaml = new Yaml()
+    private static def YAML = new Yaml()
+    private static def EMPTY_ARTIFACT = new ArtifactId("", "", "")
+
+    private static Map<String, ?>[] loadAsYaml(String text) {
+        return YAML.load(text) as Map<String, ?>[] ?: []
+    }
+
+    def targets = [
+            LibraryInfo.fromYaml(
+                    artifact: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                    notice: "NOTICE",
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // contains : with spaces
+                    libraryName: "Cookpad License : Tool",
+                    artifactId: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                    notice: "NOTICE",
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // licenseUrl is missing
+                    libraryName: "Cookpad License Tool",
+                    artifactId: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                    notice: "NOTICE",
+                    license: "Sample License",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // url is missing
+                    libraryName: "Cookpad License Tool",
+                    artifactId: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                    notice: "NOTICE",
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+            ),
+            LibraryInfo.fromYaml( // copyrightHolder is missing
+                    libraryName: "Cookpad License Tool",
+                    artifactId: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    notice: "NOTICE",
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // copyrightHolder is empty
+                    libraryName: "Cookpad License Tool",
+                    artifactId: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    copyrightHolder: "",
+                    notice: "NOTICE",
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // license is missing
+                    libraryName: "Cookpad License Tool",
+                    artifactId: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                    notice: "NOTICE",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // libraryName is missing
+                    artifactId: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                    notice: "NOTICE",
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // use filename as a fallback
+                    filename: "filename",
+                    year: "2000",
+                    copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                    notice: "NOTICE",
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // name stuff is missing
+                    year: "2000",
+                    copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                    notice: "NOTICE",
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // notice is missing
+                    artifact: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+            LibraryInfo.fromYaml( // copyright stuff is missing
+                    artifact: "com.cookpad.android:licensetools:+",
+                    filename: "filename",
+                    year: "2000",
+                    license: "Sample License",
+                    licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                    url: "https://github.com/cookpad/license-tools-plugin",
+            ),
+    ]
 
     @Test
     void testGenerateLibraryInfoText() {
-        def targets = [
-                LibraryInfo.fromYaml(
-                        artifact: "com.cookpad.android:licensetools:+",
-                        filename: "filename",
-                        year: "2000",
-                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
-                        notice: "NOTICE",
-                        license: "Sample License",
-                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
-                        url: "https://github.com/cookpad/license-tools-plugin",
-                ),
-                LibraryInfo.fromYaml( // contains : with spaces
-                        libraryName: "Cookpad License : Tool",
-                        artifactId: "com.cookpad.android:licensetools:+",
-                        filename: "filename",
-                        year: "2000",
-                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
-                        notice: "NOTICE",
-                        license: "Sample License",
-                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
-                        url: "https://github.com/cookpad/license-tools-plugin",
-                ),
-                LibraryInfo.fromYaml( // licenseUrl is missing
-                        libraryName: "Cookpad License Tool",
-                        artifactId: "com.cookpad.android:licensetools:+",
-                        filename: "filename",
-                        year: "2000",
-                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
-                        notice: "NOTICE",
-                        license: "Sample License",
-                        url: "https://github.com/cookpad/license-tools-plugin",
-                ),
-                LibraryInfo.fromYaml( // url is missing
-                        libraryName: "Cookpad License Tool",
-                        artifactId: "com.cookpad.android:licensetools:+",
-                        filename: "filename",
-                        year: "2000",
-                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
-                        notice: "NOTICE",
-                        license: "Sample License",
-                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
-                ),
-                LibraryInfo.fromYaml( // copyrightHolder is missing
-                        libraryName: "Cookpad License Tool",
-                        artifactId: "com.cookpad.android:licensetools:+",
-                        filename: "filename",
-                        year: "2000",
-                        notice: "NOTICE",
-                        license: "Sample License",
-                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
-                        url: "https://github.com/cookpad/license-tools-plugin",
-                ),
-                LibraryInfo.fromYaml( // copyrightHolder is empty
-                        libraryName: "Cookpad License Tool",
-                        artifactId: "com.cookpad.android:licensetools:+",
-                        filename: "filename",
-                        year: "2000",
-                        copyrightHolder: "",
-                        notice: "NOTICE",
-                        license: "Sample License",
-                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
-                        url: "https://github.com/cookpad/license-tools-plugin",
-                ),
-                LibraryInfo.fromYaml( // license is missing
-                        libraryName: "Cookpad License Tool",
-                        artifactId: "com.cookpad.android:licensetools:+",
-                        filename: "filename",
-                        year: "2000",
-                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
-                        notice: "NOTICE",
-                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
-                        url: "https://github.com/cookpad/license-tools-plugin",
-                ),
-                LibraryInfo.fromYaml( // libraryName is missing
-                        artifactId: "com.cookpad.android:licensetools:+",
-                        filename: "filename",
-                        year: "2000",
-                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
-                        notice: "NOTICE",
-                        license: "Sample License",
-                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
-                        url: "https://github.com/cookpad/license-tools-plugin",
-                ),
-                LibraryInfo.fromYaml( // use filename as a fallback
-                        filename: "filename",
-                        year: "2000",
-                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
-                        notice: "NOTICE",
-                        license: "Sample License",
-                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
-                        url: "https://github.com/cookpad/license-tools-plugin",
-                ),
-                LibraryInfo.fromYaml( // name stuff is missing
-                        year: "2000",
-                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
-                        notice: "NOTICE",
-                        license: "Sample License",
-                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
-                        url: "https://github.com/cookpad/license-tools-plugin",
-                ),
-        ]
-
         for (target in targets) {
             def text = LicenseToolsPlugin.generateLibraryInfoText(target)
             LibraryInfo actual = LibraryInfo.fromYaml(loadAsYaml(text)[0])
@@ -135,7 +157,32 @@ class LicenseToolsPluginTest {
         }
     }
 
-    private static Map<String, ?>[] loadAsYaml(String text) {
-        return yaml.load(text) as Map<String, ?>[] ?: []
+    @Test
+    void testGenerateMissingLibraryInfoText() {
+        for (target in targets) {
+            if (target.artifactId == EMPTY_ARTIFACT) {
+                // missing library must have artifact id
+                continue
+            }
+
+            def text = LicenseToolsPlugin.generateMissingLibraryInfoText(target)
+            LibraryInfo actual = LibraryInfo.fromYaml(loadAsYaml(text)[0])
+
+            assert target.artifactId == actual.artifactId
+            assert target.name == actual.name
+
+            if (target.copyrightStatement) {
+                assert actual.copyrightStatement == null
+            } else {
+                assert "#AUTHOR# (or authors: [...])" == actual.copyrightHolder
+                assert "#YEAR# (optional)" == actual.year
+            }
+
+            if (target.license) {
+                assert actual.license == ""
+            } else {
+                assert "#LICENSE#" == actual.license
+            }
+        }
     }
 }

--- a/plugin/src/test/groovy/com/cookpad/android/licensetools/LicenseToolsPluginTest.groovy
+++ b/plugin/src/test/groovy/com/cookpad/android/licensetools/LicenseToolsPluginTest.groovy
@@ -1,0 +1,141 @@
+package com.cookpad.android.licensetools
+
+import org.junit.Test
+import org.yaml.snakeyaml.Yaml
+
+import static com.cookpad.android.licensetools.LibraryInfo.joinWords
+
+class LicenseToolsPluginTest {
+    private static def yaml = new Yaml()
+
+    @Test
+    void testGenerateLibraryInfoText() {
+        def targets = [
+                LibraryInfo.fromYaml(
+                        artifact: "com.cookpad.android:licensetools:+",
+                        filename: "filename",
+                        year: "2000",
+                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                        notice: "NOTICE",
+                        license: "Sample License",
+                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                        url: "https://github.com/cookpad/license-tools-plugin",
+                ),
+                LibraryInfo.fromYaml( // contains : with spaces
+                        libraryName: "Cookpad License : Tool",
+                        artifactId: "com.cookpad.android:licensetools:+",
+                        filename: "filename",
+                        year: "2000",
+                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                        notice: "NOTICE",
+                        license: "Sample License",
+                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                        url: "https://github.com/cookpad/license-tools-plugin",
+                ),
+                LibraryInfo.fromYaml( // licenseUrl is missing
+                        libraryName: "Cookpad License Tool",
+                        artifactId: "com.cookpad.android:licensetools:+",
+                        filename: "filename",
+                        year: "2000",
+                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                        notice: "NOTICE",
+                        license: "Sample License",
+                        url: "https://github.com/cookpad/license-tools-plugin",
+                ),
+                LibraryInfo.fromYaml( // url is missing
+                        libraryName: "Cookpad License Tool",
+                        artifactId: "com.cookpad.android:licensetools:+",
+                        filename: "filename",
+                        year: "2000",
+                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                        notice: "NOTICE",
+                        license: "Sample License",
+                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                ),
+                LibraryInfo.fromYaml( // copyrightHolder is missing
+                        libraryName: "Cookpad License Tool",
+                        artifactId: "com.cookpad.android:licensetools:+",
+                        filename: "filename",
+                        year: "2000",
+                        notice: "NOTICE",
+                        license: "Sample License",
+                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                        url: "https://github.com/cookpad/license-tools-plugin",
+                ),
+                LibraryInfo.fromYaml( // copyrightHolder is empty
+                        libraryName: "Cookpad License Tool",
+                        artifactId: "com.cookpad.android:licensetools:+",
+                        filename: "filename",
+                        year: "2000",
+                        copyrightHolder: "",
+                        notice: "NOTICE",
+                        license: "Sample License",
+                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                        url: "https://github.com/cookpad/license-tools-plugin",
+                ),
+                LibraryInfo.fromYaml( // license is missing
+                        libraryName: "Cookpad License Tool",
+                        artifactId: "com.cookpad.android:licensetools:+",
+                        filename: "filename",
+                        year: "2000",
+                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                        notice: "NOTICE",
+                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                        url: "https://github.com/cookpad/license-tools-plugin",
+                ),
+                LibraryInfo.fromYaml( // libraryName is missing
+                        artifactId: "com.cookpad.android:licensetools:+",
+                        filename: "filename",
+                        year: "2000",
+                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                        notice: "NOTICE",
+                        license: "Sample License",
+                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                        url: "https://github.com/cookpad/license-tools-plugin",
+                ),
+                LibraryInfo.fromYaml( // use filename as a fallback
+                        filename: "filename",
+                        year: "2000",
+                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                        notice: "NOTICE",
+                        license: "Sample License",
+                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                        url: "https://github.com/cookpad/license-tools-plugin",
+                ),
+                LibraryInfo.fromYaml( // name stuff is missing
+                        year: "2000",
+                        copyrightHolder: joinWords(["Person1", "Person2", "Person3"]),
+                        notice: "NOTICE",
+                        license: "Sample License",
+                        licenseUrl: "https://github.com/cookpad/license-tools-plugin/LICENSE",
+                        url: "https://github.com/cookpad/license-tools-plugin",
+                ),
+        ]
+
+        for (target in targets) {
+            def text = LicenseToolsPlugin.generateLibraryInfoText(target)
+            LibraryInfo actual = LibraryInfo.fromYaml(loadAsYaml(text)[0])
+
+            assert target.artifactId.withWildcardVersion() == actual.artifactId.withWildcardVersion()
+            assert (target.name ?: "#NAME#") == actual.name
+            assert (target.copyrightHolder ?: "#COPYRIGHT_HOLDER#") == actual.copyrightHolder
+            assert (target.license ?: "#LICENSE#") == actual.license
+
+            if (target.licenseUrl) {
+                assert (target.licenseUrl ?: "#LICENSEURL#") == actual.licenseUrl
+            } else {
+                assert actual.licenseUrl == ""
+            }
+
+            if (target.url) {
+                assert (target.url ?: "#URL#") == actual.url
+            } else {
+                assert actual.url == null
+            }
+        }
+    }
+
+    private static Map<String, ?>[] loadAsYaml(String text) {
+        return yaml.load(text) as Map<String, ?>[] ?: []
+    }
+}


### PR DESCRIPTION
Fix #100

This plugin has been generating text by appending Strings manually, and it broke YAML compatibility in some cases.
e.g. one of the attributes includes a column with spaces, i.e. " : ".

This change allows the plugin to generate YAML compatible text like below.

```
- "artifact": "com.cookpad.android:licensetools:+"
  "name": "licensetools"
  "copyrightHolder": "#AUTHOR# (or authors: [...])"
  "year": "#YEAR# (optional)"
```