### PR TITLE
Fix crashes if uses local AAR libs.

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/ArtifactId.java
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/ArtifactId.java
@@ -19,9 +19,10 @@ public class ArtifactId implements Comparable<ArtifactId> {
             return new ArtifactId("", "", "");
         }
         String[] parts = notation.split(":");
-        assert parts.length == 3;
-
-        return new ArtifactId(parts[0], parts[1], parts[2]);
+        if (parts.length == 3) {
+            return new ArtifactId(parts[0], parts[1], parts[2]);
+        }
+        throw new IllegalArgumentException("Invalid arguments: " + notation);
     }
 
     public boolean matches(ArtifactId artifactId) {

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -121,9 +121,14 @@ class LicenseToolsPlugin implements Plugin<Project> {
             def dependencyDesc = "$d.moduleVersion.id.group:$d.moduleVersion.id.name:$d.moduleVersion.id.version"
 
             def libraryInfo = new LibraryInfo()
-            libraryInfo.artifactId = ArtifactId.parse(dependencyDesc)
-            libraryInfo.filename = d.file
-            dependencyLicenses.add(libraryInfo)
+            try {
+                libraryInfo.artifactId = ArtifactId.parse(dependencyDesc)
+                libraryInfo.filename = d.file
+                dependencyLicenses.add(libraryInfo)
+            } catch (IllegalArgumentException e) {
+                project.logger.info("Unsupport dependency: $dependencyDesc")
+                return
+            }
 
             Dependency pomDependency = project.dependencies.create("$dependencyDesc@pom")
             Configuration pomConfiguration = project.configurations.detachedConfiguration(pomDependency)


### PR DESCRIPTION
## Problem

Crashes execute `checkLicenses` if uses local AAR libs.

* build.gradle

```gradle
repositories {
    flatDir {
        dirs 'libs'
    }
}
dependencies {
    implementation(name: 'my_custom_library', ext: 'aar')
}
```

* Crash logs

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: 2
        at com.cookpad.android.licensetools.ArtifactId.parse(ArtifactId.java:24)
        at com.cookpad.android.licensetools.LicenseToolsPlugin$_loadDependencyLicenses_closure6.doCall(LicenseToolsPlugin.groovy:124)
        at com.cookpad.android.licensetools.LicenseToolsPlugin.loadDependencyLicenses(LicenseToolsPlugin.groovy:113)
        at com.cookpad.android.licensetools.LicenseToolsPlugin$loadDependencyLicenses$1.callCurrent(Unknown Source)
        at com.cookpad.android.licensetools.LicenseToolsPlugin.initialize(LicenseToolsPlugin.groovy:97)
        at com.cookpad.android.licensetools.LicenseToolsPlugin$_apply_closure1.doCall(LicenseToolsPlugin.groovy:26)
```

## Changes

1. `ArtifactId#parse` throws IllegalArgumentException if unsupported notation.
2. Skip load dependency if catches IllegalArgumentException from `ArtifactId#parse`.
