### PR TITLE
Add licenses for ICU and Bouncy Castle | Ticket #113

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
@@ -169,6 +169,10 @@ public class LibraryInfo implements Comparable<LibraryInfo> {
             case ~/(?i).*\bmopub\b.*/:
             case ~/(?i).*\bmopub\b.*\bsdk\b.*\blicense\b.*/:
                 return "mopub_sdk_license"
+            case ~/(?i).*\bicu\b.*\blicense\b.*/:
+                return "icu_license"
+            case ~/(?i).*\bbouncy\b.*\bcastle\b.*\blicense\b.*/:
+                return "bouncy_castle_license"
             default:
                 return name
         }

--- a/plugin/src/main/resources/template/licenses/bouncy_castle_license.html
+++ b/plugin/src/main/resources/template/licenses/bouncy_castle_license.html
@@ -1,0 +1,33 @@
+<div class="library">
+    <!-- https://www.bouncycastle.org/license.html -->
+    <h1 class="title">${library.name}</h1>
+    <% print library.url.isEmpty() ? "" : """<p><a href="${library.url}">${library.url}</a></p>"""
+    %>
+    <div class="license">
+        <h2>Bouncy Castle License</h2>
+        <p>
+            Copyright (c) 2000 - 2019 The Legion of the Bouncy Castle Inc.
+            (https://www.bouncycastle.org)
+        </p>
+        <p>
+            Permission is hereby granted, free of charge, to any person obtaining a copy of this
+            software and associated documentation files (the "Software"), to deal in the Software
+            without restriction, including without limitation the rights to use, copy, modify,
+            merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+            permit persons to whom the Software is furnished to do so, subject to the following
+            conditions:
+        </p>
+        <p>
+            The above copyright notice and this permission notice shall be included in all copies or
+            substantial portions of the Software.
+        </p>
+        <p>
+            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+            INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+            PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+            LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+            OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+            OTHER DEALINGS IN THE SOFTWARE.
+        </p>
+    </div>
+</div>

--- a/plugin/src/main/resources/template/licenses/icu_license.html
+++ b/plugin/src/main/resources/template/licenses/icu_license.html
@@ -1,0 +1,414 @@
+<div class="library">
+    <!-- https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE -->
+    <h1 class="title">${library.name}</h1>
+    <% print library.url.isEmpty() ? "" : """<p><a href="${library.url}">${library.url}</a></p>"""
+    %>
+    <div class="license">
+        <h2>Unicode/ICU License</h2>
+        <p>COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)</p>
+        <p>Copyright &amp;copy; 1991-2019 Unicode, Inc. All rights reserved.<br/>
+            Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+        </p>
+        <p>Permission is hereby granted, free of charge, to any person obtaining<br/>
+            a copy of the Unicode data files and any associated documentation<br/>
+            (the &quot;Data Files&quot;) or Unicode software and any associated documentation<br/>
+            (the &quot;Software&quot;) to deal in the Data Files or Software<br/>
+            without restriction, including without limitation the rights to use,<br/>
+            copy, modify, merge, publish, distribute, and/or sell copies of<br/>
+            the Data Files or Software, and to permit persons to whom the Data Files<br/>
+            or Software are furnished to do so, provided that either<br/>
+            (a) this copyright and permission notice appear with all copies<br/>
+            of the Data Files or Software, or<br/>
+            (b) this copyright and permission notice appear in associated<br/>
+            Documentation.
+        </p>
+        <p>THE DATA FILES AND SOFTWARE ARE PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF<br/>
+            ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE<br/>
+            WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND<br/>
+            NONINFRINGEMENT OF THIRD PARTY RIGHTS.<br/>
+            IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS<br/>
+            NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL<br/>
+            DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,<br/>
+            DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER<br/>
+            TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR<br/>
+            PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+        </p>
+        <p>Except as contained in this notice, the name of a copyright holder<br/>
+            shall not be used in advertising or otherwise to promote the sale,<br/>
+            use or other dealings in these Data Files or Software without prior<br/>
+            written authorization of the copyright holder.
+        </p>
+        <p>---------------------</p>
+        <p>Third-Party Software Licenses</p>
+        <p>This section contains third-party software notices and/or additional<br/>
+            terms for licensed third-party software components included within ICU<br/>
+            libraries.
+        </p>
+        <p>1. ICU License - ICU 1.8.1 to ICU 57.1</p>
+        <p>COPYRIGHT AND PERMISSION NOTICE</p>
+        <p>Copyright (c) 1995-2016 International Business Machines Corporation and others<br/>
+            All rights reserved.
+        </p>
+        <p>Permission is hereby granted, free of charge, to any person obtaining<br/>
+            a copy of this software and associated documentation files (the<br/>
+            &quot;Software&quot;), to deal in the Software without restriction, including<br/>
+            without limitation the rights to use, copy, modify, merge, publish,<br/>
+            distribute, and/or sell copies of the Software, and to permit persons<br/>
+            to whom the Software is furnished to do so, provided that the above<br/>
+            copyright notice(s) and this permission notice appear in all copies of<br/>
+            the Software and that both the above copyright notice(s) and this<br/>
+            permission notice appear in supporting documentation.
+        </p>
+        <p>THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND,<br/>
+            EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF<br/>
+            MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT<br/>
+            OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR<br/>
+            HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY<br/>
+            SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER<br/>
+            RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF<br/>
+            CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN<br/>
+            CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+        </p>
+        <p>Except as contained in this notice, the name of a copyright holder<br/>
+            shall not be used in advertising or otherwise to promote the sale, use<br/>
+            or other dealings in this Software without prior written authorization<br/>
+            of the copyright holder.
+        </p>
+        <p>All trademarks and registered trademarks mentioned herein are the<br/>
+            property of their respective owners.
+        </p>
+        <p>2. Chinese/Japanese Word Break Dictionary Data (cjdict.txt)</p>
+        <p> # The Google Chrome software developed by Google is licensed under<br/>
+            # the BSD license. Other software included in this distribution is<br/>
+            # provided under other licenses, as set forth below.<br/>
+            #<br/>
+            # The BSD License<br/>
+            # http://opensource.org/licenses/bsd-license.php<br/>
+            # Copyright (C) 2006-2008, Google Inc.<br/>
+            #<br/>
+            # All rights reserved.<br/>
+            #<br/>
+            # Redistribution and use in source and binary forms, with or without<br/>
+            # modification, are permitted provided that the following conditions are met:<br/>
+            #<br/>
+            # Redistributions of source code must retain the above copyright notice,<br/>
+            # this list of conditions and the following disclaimer.<br/>
+            # Redistributions in binary form must reproduce the above<br/>
+            # copyright notice, this list of conditions and the following<br/>
+            # disclaimer in the documentation and/or other materials provided with<br/>
+            # the distribution.<br/>
+            # Neither the name of Google Inc. nor the names of its<br/>
+            # contributors may be used to endorse or promote products derived from<br/>
+            # this software without specific prior written permission.<br/>
+            #<br/>
+            #<br/>
+            # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND<br/>
+            # CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES,<br/>
+            # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF<br/>
+            # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE<br/>
+            # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE<br/>
+            # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR<br/>
+            # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF<br/>
+            # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR<br/>
+            # BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF<br/>
+            # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING<br/>
+            # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS<br/>
+            # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.<br/>
+            #<br/>
+            #<br/>
+            # The word list in cjdict.txt are generated by combining three word lists<br/>
+            # listed below with further processing for compound word breaking. The<br/>
+            # frequency is generated with an iterative training against Google web<br/>
+            # corpora.<br/>
+            #<br/>
+            # * Libtabe (Chinese)<br/>
+            # - https://sourceforge.net/project/?group_id=1519<br/>
+            # - Its license terms and conditions are shown below.<br/>
+            #<br/>
+            # * IPADIC (Japanese)<br/>
+            # - http://chasen.aist-nara.ac.jp/chasen/distribution.html<br/>
+            # - Its license terms and conditions are shown below.<br/>
+            #<br/>
+            # ---------COPYING.libtabe ---- BEGIN--------------------<br/>
+            #<br/>
+            # /*<br/>
+            # * Copyright (c) 1999 TaBE Project.<br/>
+            # * Copyright (c) 1999 Pai-Hsiang Hsiao.<br/>
+            # * All rights reserved.<br/>
+            # *<br/>
+            # * Redistribution and use in source and binary forms, with or without<br/>
+            # * modification, are permitted provided that the following conditions<br/>
+            # * are met:<br/>
+            # *<br/>
+            # * . Redistributions of source code must retain the above copyright<br/>
+            # * notice, this list of conditions and the following disclaimer.<br/>
+            # * . Redistributions in binary form must reproduce the above copyright<br/>
+            # * notice, this list of conditions and the following disclaimer in<br/>
+            # * the documentation and/or other materials provided with the<br/>
+            # * distribution.<br/>
+            # * . Neither the name of the TaBE Project nor the names of its<br/>
+            # * contributors may be used to endorse or promote products derived<br/>
+            # * from this software without specific prior written permission.<br/>
+            # *<br/>
+            # * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS<br/>
+            # * &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT<br/>
+            # * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS<br/>
+            # * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE<br/>
+            # * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,<br/>
+            # * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES<br/>
+            # * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR<br/>
+            # * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)<br/>
+            # * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,<br/>
+            # * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)<br/>
+            # * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED<br/>
+            # * OF THE POSSIBILITY OF SUCH DAMAGE.<br/>
+            # */<br/>
+            #<br/>
+            # /*<br/>
+            # * Copyright (c) 1999 Computer Systems and Communication Lab,<br/>
+            # * Institute of Information Science, Academia<br/>
+            # * Sinica. All rights reserved.<br/>
+            # *<br/>
+            # * Redistribution and use in source and binary forms, with or without<br/>
+            # * modification, are permitted provided that the following conditions<br/>
+            # * are met:<br/>
+            # *<br/>
+            # * . Redistributions of source code must retain the above copyright<br/>
+            # * notice, this list of conditions and the following disclaimer.<br/>
+            # * . Redistributions in binary form must reproduce the above copyright<br/>
+            # * notice, this list of conditions and the following disclaimer in<br/>
+            # * the documentation and/or other materials provided with the<br/>
+            # * distribution.<br/>
+            # * . Neither the name of the Computer Systems and Communication Lab<br/>
+            # * nor the names of its contributors may be used to endorse or<br/>
+            # * promote products derived from this software without specific<br/>
+            # * prior written permission.<br/>
+            # *<br/>
+            # * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS<br/>
+            # * &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT<br/>
+            # * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS<br/>
+            # * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE<br/>
+            # * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,<br/>
+            # * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES<br/>
+            # * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR<br/>
+            # * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)<br/>
+            # * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,<br/>
+            # * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)<br/>
+            # * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED<br/>
+            # * OF THE POSSIBILITY OF SUCH DAMAGE.<br/>
+            # */<br/>
+            #<br/>
+            # Copyright 1996 Chih-Hao Tsai @ Beckman Institute,<br/>
+            # University of Illinois<br/>
+            # c-tsai4@uiuc.edu http://casper.beckman.uiuc.edu/~c-tsai4<br/>
+            #<br/>
+            # ---------------COPYING.libtabe-----END--------------------------------<br/>
+            #<br/>
+            #<br/>
+            # ---------------COPYING.ipadic-----BEGIN-------------------------------<br/>
+            #<br/>
+            # Copyright 2000, 2001, 2002, 2003 Nara Institute of Science<br/>
+            # and Technology. All Rights Reserved.<br/>
+            #<br/>
+            # Use, reproduction, and distribution of this software is permitted.<br/>
+            # Any copy of this software, whether in its original form or modified,<br/>
+            # must include both the above copyright notice and the following<br/>
+            # paragraphs.<br/>
+            #<br/>
+            # Nara Institute of Science and Technology (NAIST),<br/>
+            # the copyright holders, disclaims all warranties with regard to this<br/>
+            # software, including all implied warranties of merchantability and<br/>
+            # fitness, in no event shall NAIST be liable for<br/>
+            # any special, indirect or consequential damages or any damages<br/>
+            # whatsoever resulting from loss of use, data or profits, whether in an<br/>
+            # action of contract, negligence or other tortuous action, arising out<br/>
+            # of or in connection with the use or performance of this software.<br/>
+            #<br/>
+            # A large portion of the dictionary entries<br/>
+            # originate from ICOT Free Software. The following conditions for ICOT<br/>
+            # Free Software applies to the current dictionary as well.<br/>
+            #<br/>
+            # Each User may also freely distribute the Program, whether in its<br/>
+            # original form or modified, to any third party or parties, PROVIDED<br/>
+            # that the provisions of Section 3 (&quot;NO WARRANTY&quot;) will ALWAYS appear<br/>
+            # on, or be attached to, the Program, which is distributed substantially<br/>
+            # in the same form as set out herein and that such intended<br/>
+            # distribution, if actually made, will neither violate or otherwise<br/>
+            # contravene any of the laws and regulations of the countries having<br/>
+            # jurisdiction over the User or the intended distribution itself.<br/>
+            #<br/>
+            # NO WARRANTY<br/>
+            #<br/>
+            # The program was produced on an experimental basis in the course of the<br/>
+            # research and development conducted during the project and is provided<br/>
+            # to users as so produced on an experimental basis. Accordingly, the<br/>
+            # program is provided without any warranty whatsoever, whether express,<br/>
+            # implied, statutory or otherwise. The term &quot;warranty&quot; used herein<br/>
+            # includes, but is not limited to, any warranty of the quality,<br/>
+            # performance, merchantability and fitness for a particular purpose of<br/>
+            # the program and the nonexistence of any infringement or violation of<br/>
+            # any right of any third party.<br/>
+            #<br/>
+            # Each user of the program will agree and understand, and be deemed to<br/>
+            # have agreed and understood, that there is no warranty whatsoever for<br/>
+            # the program and, accordingly, the entire risk arising from or<br/>
+            # otherwise connected with the program is assumed by the user.<br/>
+            #<br/>
+            # Therefore, neither ICOT, the copyright holder, or any other<br/>
+            # organization that participated in or was otherwise related to the<br/>
+            # development of the program and their respective officials, directors,<br/>
+            # officers and other employees shall be held liable for any and all<br/>
+            # damages, including, without limitation, general, special, incidental<br/>
+            # and consequential damages, arising out of or otherwise in connection<br/>
+            # with the use or inability to use the program or any product, material<br/>
+            # or result produced or otherwise obtained by using the program,<br/>
+            # regardless of whether they have been advised of, or otherwise had<br/>
+            # knowledge of, the possibility of such damages at any time during the<br/>
+            # project or thereafter. Each user will be deemed to have agreed to the<br/>
+            # foregoing by his or her commencement of use of the program. The term<br/>
+            # &quot;use&quot; as used herein includes, but is not limited to, the use,<br/>
+            # modification, copying and distribution of the program and the<br/>
+            # production of secondary products from the program.<br/>
+            #<br/>
+            # In the case where the program, whether in its original form or<br/>
+            # modified, was distributed or delivered to or received by a user from<br/>
+            # any person, organization or entity other than ICOT, unless it makes or<br/>
+            # grants independently of ICOT any specific warranty to the user in<br/>
+            # writing, such person, organization or entity, will also be exempted<br/>
+            # from and not be held liable to the user for any such damages as noted<br/>
+            # above as far as the program is concerned.<br/>
+            #<br/>
+            # ---------------COPYING.ipadic-----END----------------------------------
+        </p>
+        <p>3. Lao Word Break Dictionary Data (laodict.txt)</p>
+        <p> # Copyright (c) 2013 International Business Machines Corporation<br/>
+            # and others. All Rights Reserved.<br/>
+            #<br/>
+            # Project: http://code.google.com/p/lao-dictionary/<br/>
+            # Dictionary: http://lao-dictionary.googlecode.com/git/Lao-Dictionary.txt<br/>
+            # License: http://lao-dictionary.googlecode.com/git/Lao-Dictionary-LICENSE.txt<br/>
+            # (copied below)<br/>
+            #<br/>
+            # This file is derived from the above dictionary, with slight<br/>
+            # modifications.<br/>
+            # ----------------------------------------------------------------------<br/>
+            # Copyright (C) 2013 Brian Eugene Wilson, Robert Martin Campbell.<br/>
+            # All rights reserved.<br/>
+            #<br/>
+            # Redistribution and use in source and binary forms, with or without<br/>
+            # modification,<br/>
+            # are permitted provided that the following conditions are met:<br/>
+            #<br/>
+            #<br/>
+            # Redistributions of source code must retain the above copyright notice, this<br/>
+            # list of conditions and the following disclaimer. Redistributions in<br/>
+            # binary form must reproduce the above copyright notice, this list of<br/>
+            # conditions and the following disclaimer in the documentation and/or<br/>
+            # other materials provided with the distribution.<br/>
+            #<br/>
+            #<br/>
+            # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS<br/>
+            # &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT<br/>
+            # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS<br/>
+            # FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE<br/>
+            # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,<br/>
+            # INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES<br/>
+            # (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR<br/>
+            # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)<br/>
+            # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,<br/>
+            # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)<br/>
+            # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED<br/>
+            # OF THE POSSIBILITY OF SUCH DAMAGE.<br/>
+            # --------------------------------------------------------------------------
+        </p>
+        <p>4. Burmese Word Break Dictionary Data (burmesedict.txt)</p>
+        <p> # Copyright (c) 2014 International Business Machines Corporation<br/>
+            # and others. All Rights Reserved.<br/>
+            #<br/>
+            # This list is part of a project hosted at:<br/>
+            # github.com/kanyawtech/myanmar-karen-word-lists<br/>
+            #<br/>
+            # --------------------------------------------------------------------------<br/>
+            # Copyright (c) 2013, LeRoy Benjamin Sharon<br/>
+            # All rights reserved.<br/>
+            #<br/>
+            # Redistribution and use in source and binary forms, with or without<br/>
+            # modification, are permitted provided that the following conditions<br/>
+            # are met: Redistributions of source code must retain the above<br/>
+            # copyright notice, this list of conditions and the following<br/>
+            # disclaimer. Redistributions in binary form must reproduce the<br/>
+            # above copyright notice, this list of conditions and the following<br/>
+            # disclaimer in the documentation and/or other materials provided<br/>
+            # with the distribution.<br/>
+            #<br/>
+            # Neither the name Myanmar Karen Word Lists, nor the names of its<br/>
+            # contributors may be used to endorse or promote products derived<br/>
+            # from this software without specific prior written permission.<br/>
+            #<br/>
+            # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND<br/>
+            # CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES,<br/>
+            # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF<br/>
+            # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE<br/>
+            # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS<br/>
+            # BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,<br/>
+            # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED<br/>
+            # TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,<br/>
+            # DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON<br/>
+            # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR<br/>
+            # TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF<br/>
+            # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF<br/>
+            # SUCH DAMAGE.<br/>
+            # --------------------------------------------------------------------------
+        </p>
+        <p>5. Time Zone Database</p>
+        <p> ICU uses the public domain data and code derived from Time Zone<br/>
+            Database for its time zone support. The ownership of the TZ database<br/>
+            is explained in BCP 175: Procedure for Maintaining the Time Zone<br/>
+            Database section 7.
+        </p>
+        <p> # 7. Database Ownership<br/>
+            #<br/>
+            # The TZ database itself is not an IETF Contribution or an IETF<br/>
+            # document. Rather it is a pre-existing and regularly updated work<br/>
+            # that is in the public domain, and is intended to remain in the<br/>
+            # public domain. Therefore, BCPs 78 [RFC5378] and 79 [RFC3979] do<br/>
+            # not apply to the TZ Database or contributions that individuals make<br/>
+            # to it. Should any claims be made and substantiated against the TZ<br/>
+            # Database, the organization that is providing the IANA<br/>
+            # Considerations defined in this RFC, under the memorandum of<br/>
+            # understanding with the IETF, currently ICANN, may act in accordance<br/>
+            # with all competent court orders. No ownership claims will be made<br/>
+            # by ICANN or the IETF Trust on the database or the code. Any person<br/>
+            # making a contribution to the database or code waives all rights to<br/>
+            # future claims in that contribution or in the TZ Database.
+        </p>
+        <p>6. Google double-conversion</p>
+        <p>Copyright 2006-2011, the V8 project authors. All rights reserved.<br/>
+            Redistribution and use in source and binary forms, with or without<br/>
+            modification, are permitted provided that the following conditions are<br/>
+            met:
+        </p>
+        <p> * Redistributions of source code must retain the above copyright<br/>
+            notice, this list of conditions and the following disclaimer.<br/>
+            * Redistributions in binary form must reproduce the above<br/>
+            copyright notice, this list of conditions and the following<br/>
+            disclaimer in the documentation and/or other materials provided<br/>
+            with the distribution.<br/>
+            * Neither the name of Google Inc. nor the names of its<br/>
+            contributors may be used to endorse or promote products derived<br/>
+            from this software without specific prior written permission.
+        </p>
+        <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS<br/>
+            &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT<br/>
+            LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR<br/>
+            A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT<br/>
+            OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,<br/>
+            SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT<br/>
+            LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,<br/>
+            DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY<br/>
+            THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT<br/>
+            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE<br/>
+            OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+        </p>
+    </div>
+</div>

--- a/plugin/src/test/groovy/com/cookpad/android/licensetools/LibraryInfoTest.groovy
+++ b/plugin/src/test/groovy/com/cookpad/android/licensetools/LibraryInfoTest.groovy
@@ -295,6 +295,17 @@ public class LibraryInfoTest {
         assertNotEquals("mopub_sdk_license", normalizeLicense("BSD"))
         assertNotEquals("mopub_sdk_license", normalizeLicense("MIT"))
 
+        // ICU License
+        assertEquals("icu_license", normalizeLicense("ICU License"))
+        assertNotEquals("icu_license", normalizeLicense("BSD"))
+        assertNotEquals("icu_license", normalizeLicense("MIT"))
+
+        // Bouncy Castle License
+        assertEquals("bouncy_castle_license", normalizeLicense("Bouncy Castle License"))
+        assertNotEquals("bouncy_castle_license", normalizeLicense("BSD"))
+        assertNotEquals("bouncy_castle_license", normalizeLicense("MIT"))
+
+
         // Other
         assertEquals("Other", normalizeLicense("Other"))
         assertEquals("No license found", normalizeLicense("No license found"))


### PR DESCRIPTION
This PR adds the missing license files for `Bouncy Castle Licenses` and `ICU License` (which is owned by `Unicode` now).

Here is the ticket: https://github.com/cookpad/license-tools-plugin/issues/113