### PR TITLE
Use escapedName to generate valid library YAML

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -207,7 +207,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
     static String generateLibraryInfoText(LibraryInfo libraryInfo) {
         def text = new StringBuffer()
         text.append("- artifact: ${libraryInfo.artifactId.withWildcardVersion()}\n")
-        text.append("  name: ${libraryInfo.name ?: "#NAME#"}\n")
+        text.append("  name: ${libraryInfo.escapedName ?: "#NAME#"}\n")
         text.append("  copyrightHolder: ${libraryInfo.copyrightHolder ?: "#COPYRIGHT_HOLDER#"}\n")
         text.append("  license: ${libraryInfo.license ?: "#LICENSE#"}\n")
         if (libraryInfo.licenseUrl) {


### PR DESCRIPTION
Fix #100

When a library info entry is generated via the `updateLicenses` task, if the library's name contains a colon (`:`), the resulting output is invalidly-formatted YAML:

```
- artifact: com.squareup.retrofit2:adapter-rxjava2:+
  name: Adapter: RxJava 2
```

This invalid YAML prevents the `licenses.yml` file from being properly parsed by the `checkLicenses`, `generateLicensePage`, and `generateLicenseJson` tasks:

```
Execution failed for task ':example:checkLicenses'.
> mapping values are not allowed here
   in 'string', line 143, column 16:
        name: Adapter: RxJava 2
```

PR #59 introduced a function for handling library names with colons, but use of that function appears to have been unintentionally not carried over in PR #86.

This PR utilizes `escapedName` from #59 so that library names with colons are surrounded with quotes:

```yaml
- artifact: com.squareup.retrofit2:adapter-rxjava2:+
  name: "Adapter: RxJava 2"
```