### PR TITLE
Add SPDX identifier and copyright in source code

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/ArtifactId.java
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/ArtifactId.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.licensetools;
 
 public class ArtifactId implements Comparable<ArtifactId> {

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/DependencySet.java
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/DependencySet.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.licensetools;
 
 import java.util.ArrayList;

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LibraryInfo.groovy
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.licensetools
 
 public class LibraryInfo implements Comparable<LibraryInfo> {

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsExtension.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsExtension.groovy
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.licensetools
 
 public class LicenseToolsExtension {

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.licensetools
 
 import groovy.json.JsonBuilder

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/NotEnoughInformationException.java
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/NotEnoughInformationException.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.licensetools;
 
 public class NotEnoughInformationException extends RuntimeException {

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/Templates.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/Templates.groovy
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2016 Cookpad Inc.
+
 package com.cookpad.android.licensetools
 
 import groovy.text.SimpleTemplateEngine


### PR DESCRIPTION
I added SPDX identifier and copyright in source codes.

In the Linux project, they added the SPDX identifier to solve the open source License compliance in the source. Please take a loot at the pages.

1. https://www.linuxfoundation.org/blog/2018/08/solving-license-compliance-at-the-source-adding-spdx-license-ids/
2. https://spdx.org/using-spdx-license-identifier

So I contributed to add it in source codes of license-tool-plugin.