### PR TITLE
Fixed layout collapse when the source library URL is long

### DIFF
--- a/plugin/src/main/resources/template/layout.html
+++ b/plugin/src/main/resources/template/layout.html
@@ -72,6 +72,9 @@
     input:checked ~ .license {
     max-height: none;
     }
+    a {
+    overflow-wrap: break-word;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## 課題
ライブラリ提供元のURLが長い場合、licenses.htmlを表示するときにレイアウトが崩れてしまう

## 修正内容
- `resources/template/layout.html` に、URLが長い場合に自動で折り返すCSSを追加する
