### PR TITLE
Extract configuration regex to extensions.

### DIFF
--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsExtension.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsExtension.groovy
@@ -13,4 +13,7 @@ public class LicenseToolsExtension {
     public Set<String> ignoredGroups = new HashSet<>()
 
     public Set<String> ignoredProjects = new HashSet<>()
+
+    public String configurationRegex = /^(?!releaseUnitTest)(?:release\w*)?([cC]ompile|[cC]ompileOnly|[iI]mplementation|[aA]pi)$/
+
 }

--- a/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
+++ b/plugin/src/main/groovy/com/cookpad/android/licensetools/LicenseToolsPlugin.groovy
@@ -304,6 +304,8 @@ class LicenseToolsPlugin implements Plugin<Project> {
 
     // originated from https://github.com/hierynomus/license-gradle-plugin DependencyResolver.groovy
     Set<ResolvedArtifact> resolveProjectDependencies(Project project, Set<String> ignoredProjects) {
+        LicenseToolsExtension ext = project.extensions.findByType(LicenseToolsExtension)
+
         def subprojects = project.rootProject.subprojects.findAll { Project p -> !ignoredProjects.contains(p.name) }
                 .groupBy { Project p -> "$p.group:$p.name:$p.version" }
 
@@ -312,7 +314,7 @@ class LicenseToolsPlugin implements Plugin<Project> {
         project.rootProject.subprojects.findAll { Project p -> !ignoredProjects.contains(p.name) }.each { Project subproject ->
             runtimeDependencies << subproject.configurations.all.findAll { Configuration c ->
                 // compile|implementation|api, release(Compile|Implementation|Api), releaseProduction(Compile|Implementation|Api), and so on.
-                c.name.matches(/^(?!releaseUnitTest)(?:release\w*)?([cC]ompile|[cC]ompileOnly|[iI]mplementation|[aA]pi)$/)
+                c.name.matches(ext.configurationRegex)
             }.collect {
                 Configuration copyConfiguration = it.copyRecursive()
                 copyConfiguration.setCanBeResolved(true)


### PR DESCRIPTION
Hi,

In my current project, we're using custom configuration which is not accessible with a regex specified in `resolveProjectDependencies` method. Let's extract a configuration variable so we can use custom rules.